### PR TITLE
Bump python

### DIFF
--- a/wlutil/test.py
+++ b/wlutil/test.py
@@ -67,7 +67,7 @@ def cmpOutput(testDir, refDir, strip=False):
                     else:
                         # I'm not 100% sure what will happen with a binary file
                         diffString = "".join(difflib.unified_diff(rFile.readlines(),
-                                tFile.readlines(), fromfile=rPath, tofile=tPath))
+                                tFile.readlines(), fromfile=str(rPath), tofile=str(tPath)))
                         if diffString is not "":
                             return diffString
 


### PR DESCRIPTION
The python bump in firesim broke marshal tests with outputs. This fixes it. I suspect this wasn't caught earlier because full_test.sh has been failing to report errors properly (soon to be fixed, see #26 ).