### PR TITLE
Fix full test

### DIFF
--- a/test/dummy-bare/build.sh
+++ b/test/dummy-bare/build.sh
@@ -3,3 +3,8 @@
 pushd ../bare
 make
 popd
+
+if [ ! -f hello ]; then
+  ln -s ../bare/hello .
+fi
+

--- a/test/spike/.gitignore
+++ b/test/spike/.gitignore
@@ -1,3 +1,4 @@
 *.o
 riscv-isa-sim
 spike_local
+hello

--- a/test/spike/build.sh
+++ b/test/spike/build.sh
@@ -1,5 +1,36 @@
 #!/bin/bash
+set -e
+
+SPIKE_INSTALL=$PWD/spike_local
+mkdir -p $SPIKE_INSTALL
+
+# Get the custom spike
+if [ ! -d riscv-isa-sim ]; then
+  git clone https://github.com/riscv/riscv-isa-sim.git
+  pushd riscv-isa-sim
+  git checkout 2dbcb01ca1c026b867cf673203646d213f6e6b5c
+  popd
+
+  pushd riscv-isa-sim
+  git apply ../spike.patch
+
+  mkdir build
+  pushd build
+  ../configure --with-fesvr=$RISCV --prefix=$SPIKE_INSTALL
+  popd
+  popd
+fi
+
+pushd riscv-isa-sim/build
+make -j16
+make install
+popd
 
 pushd ../bare
 make
 popd
+
+if [ ! -f hello ]; then
+  ln -s ../bare/hello .
+fi
+

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -214,6 +214,7 @@ class Config(collections.MutableMapping):
         # if 'linux-config' in self.cfg:
             self.cfg['bin'] = os.path.join(image_dir, self.cfg['name'] + "-bin")
 
+        # Some defaults need to occur, even if you don't have a base
         if 'launch' not in self.cfg:
             self.cfg['launch'] = True
 
@@ -330,6 +331,10 @@ class ConfigManager(collections.MutableMapping):
                     self._initializeFromBase(baseCfg)
 
                 cfg.applyBase(baseCfg)
+            else:
+                # Some defaults need to occur, even if you don't have a base
+                if 'launch' not in cfg:
+                    cfg['launch'] = True
 
             # must set initialized to True before handling jobs because jobs
             # will reference this config (we'd infinite loop without memoization)

--- a/wlutil/test.py
+++ b/wlutil/test.py
@@ -67,7 +67,7 @@ def cmpOutput(testDir, refDir, strip=False):
                     else:
                         # I'm not 100% sure what will happen with a binary file
                         diffString = "".join(difflib.unified_diff(rFile.readlines(),
-                                tFile.readlines(), fromfile=rPath, tofile=tPath))
+                                tFile.readlines(), fromfile=str(rPath), tofile=str(tPath)))
                         if diffString is not "":
                             return diffString
 


### PR DESCRIPTION
Lots of bit rot that festered due to a bug in the test script which was masking errors. full_test.sh should now work, and hopefully we can keep it that way. The only (slight) functional change is in how marshal detects 'skippable' workloads (workloads that are not intended to be run during testing). It's a minor change to a rarely used feature.