### PR TITLE
Spike jobs

### DIFF
--- a/test/spike-jobs.json
+++ b/test/spike-jobs.json
@@ -1,0 +1,16 @@
+{
+  "name" : "spike-jobs",
+  "workdir" : "spike",
+  "base" : "spike.json",
+  "testing" : {
+    "refDir" : "refJobs"
+  },
+  "jobs" : [
+    {
+      "name" : "j0"
+    },
+    {
+      "name" : "j1"
+    }
+  ]
+}

--- a/test/spike/refJobs/spike-jobs-j0/uartlog
+++ b/test/spike/refJobs/spike-jobs-j0/uartlog
@@ -1,0 +1,3 @@
+Global : spike
+Hello World
+Global : spike

--- a/test/spike/refJobs/spike-jobs-j1/uartlog
+++ b/test/spike/refJobs/spike-jobs-j1/uartlog
@@ -1,0 +1,3 @@
+Global : spike
+Hello World
+Global : spike

--- a/wlutil/launch.py
+++ b/wlutil/launch.py
@@ -62,8 +62,8 @@ def launchWorkload(cfgName, cfgs, job='all', spike=False):
     baseConfig = cfgs[cfgName]
 
     # Bare-metal tests don't work on qemu yet
-    if baseConfig.get('distro') == 'bare':
-        spike = True
+    if baseConfig.get('distro') == 'bare' and spike != True:
+        raise RuntimeError("Bare-metal workloads do not currently support Qemu. Please run this workload under spike.")
 
     if 'jobs' in baseConfig.keys() and job != 'all':
         # Run the specified job

--- a/wlutil/test.py
+++ b/wlutil/test.py
@@ -205,7 +205,7 @@ def testWorkload(cfgName, cfgs, verbose=False, spike=False, cmp_only=None):
                 # Run every job (or just the workload itself if no jobs)
                 if 'jobs' in cfg:
                     for jName in cfg['jobs'].keys():
-                        runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, job=jName)
+                        runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, job=jName, spike=spike)
                 else:
                     runTimeout(launchWorkload, testCfg['runTimeout'])(cfgName, cfgs, spike=spike)
             


### PR DESCRIPTION
Fix #33 

This does change the default behavior somewhat:
Previously, marshal would automatically switch all bare-metal workloads to use spike, regardless of how you launched the workload. Now, it throws an error (qemu can't run bare-metal workloads right now). You must explicitly use spike. This was done for a few reasons:
1. We shouldn't have undocumented, silent behaviors. I'd rather every workload behave as similarly as possible.
1. The qemu issue with bare-metal will presumably be fixed eventually. We'd need to perform this change then anyway.
1. This behavior was masking other bugs. 
 
Draft because it depends on a number of other outstanding PRs and I want to merge them in order (it merged #29 ). 