### PR TITLE
Update docs16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,21 @@
+# Changelog
+
+This changelog follows the format defined here: https://keepachangelog.com/en/1.0.0/
+
+## [1.6.0] - 2019-06-25
+This release introduces a number of bug-fixes and support for standalone behavior (marshal can now be cloned by itself on a machine without sudo). It also synchronizes with firesim release 1.6.
+
+### Added
+* PR #31 allows firesim-software to work outside of a firesim environment without the need for sudo (just riscv-tools, qemu, and a few package requirements).
+* PR #24 adds support for parallel 'launch' or 'test' commands.
+
+### Changed
+* PR #25 updates buildroot to a more recent version in order to support a more recent version of riscv-tools (as needed by firesim).
+    * PR #32 finalizes the riscv-tools at gcc 7.2
+* PR #22 enables multiple repository mirrors in the default fedora image
+
+### Fixed
+* PR #34 resolves #33 
+* PR #29 fixes a number of issues with the full_test.sh script (bug #26 )
+* PR #28 fixes an incompatibility with python36
+    * Note that #31 officially updated the python version to 3.6, but firesim de-facto updated it in an earlier release.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,24 @@
+Copyright (c) 2017-2019, The Regents of the University of California
+(Regents).  All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. Neither the name of the Regents nor the
+   names of its contributors may be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT,
+SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING
+OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS
+BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE. THE SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED
+HEREUNDER IS PROVIDED "AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/README.md
+++ b/README.md
@@ -11,9 +11,32 @@ https://docs.fires.im/en/latest/Advanced-Usage/FireMarshal/index.html
 You can also find the latest FireSim source at:
 https://github.com/firesim/firesim
 
-## Requirements
-This project was written for python 3.4
+# Requirements
+The easiest way to use Marshal is to run it via firesim on Amazon EC2 by
+following the instructions at https://docs.fires.im/en/latest/. However, this
+is not required. To run Firemarshal independently, you will need the following
+dependencies:
 
-python-requirements.txt and centos-requirements.txt are incomplete lists of
-required packages for python3. If you find that you need a package not in those
-lists, please file an issue.
+## Standard Packages
+centos-requirements.txt is a list of packages for centos7 that are needed by marshal. You can install these with:
+```
+cat centos-requirements.txt | sudo xargs yum install -y
+```
+
+Package names may be different on other distributions.
+
+### Note for Ubuntu
+The libguestfs-tools package (needed for the guestmount command) does not work
+out of the box on Ubuntu. See
+https://github.com/firesim/firesim-software/issues/30 for a workaround.
+
+## Python
+This project was written for python 3.6. You can install all dependencies using:
+```
+pip3 install python-requirements.txt
+```
+
+## riscv-tools
+In addition to standard libraries, you will need riscv-tools
+(https://github.com/firesim/riscv-tools.git). This was last tested with commit
+bce7b5e (gcc version 7.2).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 FireMarshal (firesim-software)
+Version 1.6
 ==================================
 
 This tool builds base images for several linux-based distros that work with qemu,
@@ -18,7 +19,8 @@ is not required. To run Firemarshal independently, you will need the following
 dependencies:
 
 ## Standard Packages
-centos-requirements.txt is a list of packages for centos7 that are needed by marshal. You can install these with:
+centos-requirements.txt is a list of packages for centos7 that are needed by
+marshal. You can install these with:
 ```
 cat centos-requirements.txt | sudo xargs yum install -y
 ```


### PR DESCRIPTION
Some documentation updates related to the 1.6 release. In particular, it clarifies requirements, adds a LICENSE, and adds a CHANGELOG. Since firesim-software is now functional outside of firesim, this seems prudent. It still links to fires.im for full documentation.