### PR TITLE
Add support for simulator arguments (qemu or spike).

### DIFF
--- a/full_test.sh
+++ b/full_test.sh
@@ -40,7 +40,7 @@ fi
 # shouldn't be tested (e.g. we exclude the base configs and some specialized
 # tests)
 echo "Running regular tests" | tee -a $LOGNAME
-BULK_EXCLUDE="(br-base|fedora-base|incremental|clean|timeout-build|timeout-run|bare|dummy-bare|spike-jobs|spike)"
+BULK_EXCLUDE="(br-base|fedora-base|incremental|clean|timeout-build|timeout-run|bare|dummy-bare|spike-jobs|spike|spike-args)"
 ./marshal clean test/!$BULK_EXCLUDE.json | tee -a $LOGNAME
 ./marshal test test/!$BULK_EXCLUDE.json | tee -a $LOGNAME
 if [ ${PIPESTATUS[0]} != 0 ]; then
@@ -52,7 +52,7 @@ fi
 
 # These tests need to run on spike, but not with the initramfs option
 echo "Running bare-metal tests" | tee -a $LOGNAME
-IS_INCLUDE="@(bare|dummy-bare|spike|spike-jobs)"
+IS_INCLUDE="@(bare|dummy-bare|spike|spike-jobs|spike-args)"
 ./marshal clean test/$IS_INCLUDE.json | tee -a $LOGNAME
 # This is a temporary workaround for bug #38
 ./marshal build test/spike.json

--- a/test/qemu-args.json
+++ b/test/qemu-args.json
@@ -1,0 +1,8 @@
+{
+  "name" : "qemu-args",
+  "base" : "br-base.json",
+  "qemu-args" : "--version",
+  "testing" : {
+      "refDir" : "refOutput"
+  }
+}

--- a/test/qemu-args/refOutput/qemu-args/uartlog
+++ b/test/qemu-args/refOutput/qemu-args/uartlog
@@ -1,0 +1,2 @@
+QEMU emulator version 3.0.50
+Copyright (c) 2003-2017 Fabrice Bellard and the QEMU Project developers

--- a/test/spike-args.json
+++ b/test/spike-args.json
@@ -1,0 +1,9 @@
+{
+  "name" : "spike-args",
+  "bin" : "hello",
+  "host-init" : "build.sh",
+  "spike-args" : "--dump-dts",
+  "testing" : {
+    "refDir" : "refOutput"
+  }
+}

--- a/test/spike-args/build.sh
+++ b/test/spike-args/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -e
+
+pushd ../bare
+make
+popd
+
+if [ ! -f hello ]; then
+  ln -s ../bare/hello .
+fi

--- a/test/spike-args/hello
+++ b/test/spike-args/hello
@@ -1,0 +1,1 @@
+../bare/hello

--- a/test/spike-args/refOutput/spike-args/uartlog
+++ b/test/spike-args/refOutput/spike-args/uartlog
@@ -1,0 +1,2 @@
+  compatible = "ucbbar,spike-bare-dev";
+  model = "ucbbar,spike-bare";

--- a/wlutil/config.py
+++ b/wlutil/config.py
@@ -1,8 +1,8 @@
 import os
 import glob
-import wlutil.br.br as br
-import wlutil.fedora.fedora as fed
-import wlutil.baremetal.bare as bare
+from .br import br
+from .fedora import fedora as fed
+from .baremetal import bare
 import collections
 import json
 import pprint
@@ -21,6 +21,10 @@ configUser = [
         'base',
         # Path to spike binary to use (use $PATH if this is omitted)
         'spike',
+        # Optional extra arguments to spike
+        'spike-args',
+        # Optional extra arguments to qemu
+        'qemu-args',
         # Path to riscv-linux source to use (defaults to the included linux)
         'linux-src',
         # Path to linux configuration file to use
@@ -69,7 +73,20 @@ configToAbs = ['guest-init', 'run', 'overlay', 'linux-src', 'linux-config', 'hos
 
 # These are the options that should be inherited from base configs (if not
 # explicitly provided)
-configInherit = ['runSpec', 'files', 'outputs', 'linux-src', 'linux-config', 'builder', 'distro', 'spike', 'launch', 'bin', 'post_run_hook']
+configInherit = [
+        'runSpec',
+        'files',
+        'outputs',
+        'linux-src',
+        'linux-config',
+        'builder',
+        'distro',
+        'spike',
+        'launch',
+        'bin',
+        'post_run_hook',
+        'spike-args',
+        'qemu-args']
 
 # These are the permissible base-distributions to use (they get treated special)
 distros = {

--- a/wlutil/launch.py
+++ b/wlutil/launch.py
@@ -22,9 +22,9 @@ def getSpikeCmd(config, initramfs=False):
         spikeBin = 'spike'
 
     if initramfs:
-        return spikeBin + ' -p' + launch_cores + ' -m' + launch_mem + " " + config['bin'] + '-initramfs'
+        return spikeBin + " " + config.get('spike-args', '') + ' -p' + launch_cores + ' -m' + launch_mem + " " + config['bin'] + '-initramfs'
     elif 'img' not in config:
-        return spikeBin + ' -p' + launch_cores + ' -m' + launch_mem + " " + config['bin']
+        return spikeBin + " " + config.get('spike-args', '') + ' -p' + launch_cores + ' -m' + launch_mem + " " + config['bin']
     else:
         raise ValueError("Spike does not support disk-based configurations")
 
@@ -55,7 +55,7 @@ def getQemuCmd(config, initramfs=False):
                      '-drive', 'file=' + config['img'] + ',format=raw,id=hd0']
         cmd = cmd + ['-append', '"ro root=/dev/vda"']
 
-    return " ".join(cmd)
+    return " ".join(cmd) + " " + config.get('qemu-args', '')
 
 def launchWorkload(cfgName, cfgs, job='all', spike=False):
     log = logging.getLogger()
@@ -86,6 +86,7 @@ def launchWorkload(cfgName, cfgs, job='all', spike=False):
         else:
             cmd = getQemuCmd(config, config['initramfs'])
 
+        log.info("Running: " + "".join(cmd))
         sp.check_call(cmd + " | tee " + uartLog, shell=True)
 
         if 'outputs' in config:


### PR DESCRIPTION
This is needed at least for rocc accelerators (to pass the "--extension=" arg to spike). It also lets you set one-off stuff like "-s" to add gdb support to qemu.