### PR TITLE
Fix buildroot clean not work

### DIFF
--- a/boards/default/distros/br/br.py
+++ b/boards/default/distros/br/br.py
@@ -264,9 +264,8 @@ class Builder:
             # # This is unfortunate but buildroot can't remove things from the
             # # image without rebuilding everything from scratch. It adds 20min
             # # to the unit tests and anyone who builds a custom buildroot.
-            wlutil.run(['rm', '-rf', 'overlay/*'], cwd=br_dir, env=env)
-            wlutil.run(['rm', '-rf', "buildroot/output/target/*"], cwd=br_dir, env=env)
-            wlutil.run(['find', 'buildroot/output/', '-name', '".stamp_target_installed"', '-delete'], cwd=br_dir, env=env)
+            wlutil.run(['rm', '-rf', 'buildroot/output/target'], cwd=br_dir, env=env)
+            wlutil.run(['find', 'buildroot/output/', '-name', '.stamp_target_installed', '-delete'], cwd=br_dir, env=env)
 
             wlutil.run(['make'], cwd=br_dir / "buildroot", env=env)
 


### PR DESCRIPTION
These three clean not work:
1. with wildcards, shell=True should be passed. But if delete overlay/* really, build will fail because of missing etc/init.d/S99run. It's not necessary to clean overlay, it's overwritten every time.

2. with wildcards, shell=True should be passed. We can delete target directly

3. '".stamp_target_installed"' not match our expected.