### PR TITLE
Change Fedora Rawhide URL to its new location under archive/

### DIFF
--- a/boards/default/distros/fedora/Makefile
+++ b/boards/default/distros/fedora/Makefile
@@ -1,4 +1,4 @@
-RAWURL=https://dl.fedoraproject.org/pub/alt/risc-v/repo/virt-builder-images/images/Fedora-Minimal-Rawhide-20191123.n.1-sda.raw.xz
+RAWURL=https://dl.fedoraproject.org/pub/alt/risc-v/archive/repo/virt-builder-images/images/Fedora-Minimal-Rawhide-20191123.n.1-sda.raw.xz
 COMPIMG=rootfs.img.xz
 NEWIMG=rootfs.img
 


### PR DESCRIPTION
Sometime in the past 8-12 months, Fedora moved their virt-builder image for Fedora Rawhide 20191123.n.1 under an archive/ URL. Update the Makefile to reflect this change.